### PR TITLE
Add azkv-ssh-fetch to projects list

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,3 +1,13 @@
+- name: azkv-ssh-fetch
+  url: https://github.com/NaeemH/azkv-ssh-fetch
+  description: Python CLI that pulls SSH private keys from Azure Key Vault and connects to VMs / VMSS instances through Azure Bastion &mdash; one command, atomic writes, mode 0600.
+  used:
+    - thing: Python
+    - thing: Typer
+    - thing: Azure SDK
+    - thing: Azure Key Vault
+    - thing: Azure Bastion
+
 - name: NemoNet
   url: https://github.com/NaeemH/NemoNet
   description: Convolutional neural net trained to recognize wildlife fish &mdash; including everyone's favorite clownfish.


### PR DESCRIPTION
Add `azkv-ssh-fetch` to the projects list — newly-published OSS CLI.

## What

Prepends a new entry at the top of `_data/projects.yml` linking to [NaeemH/azkv-ssh-fetch](https://github.com/NaeemH/azkv-ssh-fetch), a Python CLI that pulls SSH private keys from Azure Key Vault and connects to VMs/VMSS instances through Azure Bastion.

## Why

Most-recent project belongs at the top of the list. This one ships v0.1.0 with:
- Typer-based CLI (`akf list | fetch | connect`)
- DefaultAzureCredential + SecretClient
- Atomic key writes to `~/.ssh` with mode `0600`
- Optional key shred on Bastion disconnect
- 22 tests, ruff + mypy strict, GitHub Actions matrix (py3.10/3.11/3.12)

## Preview

Renders inside the existing Projects section on the home page using the same template that handles every other entry — no markup changes needed.
