### PR TITLE
Add 'Published' section for PyPI packages

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -1,0 +1,14 @@
+- name: azkv-ssh-fetch
+  description: Python CLI that pulls SSH private keys from Azure Key Vault and connects to VMs / VMSS instances through Azure Bastion. Atomic key writes with mode 0600, optional key shred on disconnect, full <code>az</code> CLI integration.
+  install: pipx install azkv-ssh-fetch
+  links:
+    - label: PyPI
+      url: https://pypi.org/project/azkv-ssh-fetch/
+    - label: GitHub
+      url: https://github.com/NaeemH/azkv-ssh-fetch
+  used:
+    - thing: Python
+    - thing: Typer
+    - thing: Azure SDK
+    - thing: Azure Key Vault
+    - thing: Azure Bastion

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,13 +1,3 @@
-- name: azkv-ssh-fetch
-  url: https://github.com/NaeemH/azkv-ssh-fetch
-  description: Python CLI that pulls SSH private keys from Azure Key Vault and connects to VMs / VMSS instances through Azure Bastion &mdash; one command, atomic writes, mode 0600.
-  used:
-    - thing: Python
-    - thing: Typer
-    - thing: Azure SDK
-    - thing: Azure Key Vault
-    - thing: Azure Bastion
-
 - name: NemoNet
   url: https://github.com/NaeemH/NemoNet
   description: Convolutional neural net trained to recognize wildlife fish &mdash; including everyone's favorite clownfish.

--- a/_includes/packages.html
+++ b/_includes/packages.html
@@ -1,0 +1,24 @@
+<section class="section other-projects packages">
+  <div class="section__title">Published</div>
+  <div class="section__content">
+    {% for pkg in site.data.packages %}
+    <div class="project package">
+      <div class="project__name">{{ pkg.name }}</div>
+      <p>{{ pkg.description }}</p>
+      {% if pkg.install %}
+      <pre class="package__install" aria-label="install command"><code>{{ pkg.install }}</code></pre>
+      {% endif %}
+      <div class="package__links">
+        {% for link in pkg.links %}
+        <a href="{{ link.url }}" target="_blank" rel="noopener" class="arrow-link">{{ link.label }}</a>
+        {% endfor %}
+      </div>
+      <div class="project__used">
+        {% for item in pkg.used %}
+        <span class="project__used__item">{{ item.thing }}</span>
+        {% endfor %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</section>

--- a/css/main.css
+++ b/css/main.css
@@ -7,3 +7,13 @@ body.night .intro__currently .currently-label{color:#4dabff}
 .intro__currently{min-height:3em}
 @media screen and (max-width:550px){.intro__currently{min-height:4.5em}}
 #header .avatar img{aspect-ratio:1/1}
+/* Packages / published-work section (added 2026-06-22) */
+.packages .package{margin-bottom:50px}
+.packages .package:last-of-type{margin-bottom:0}
+.packages .package .project__name{margin-bottom:10px;font-weight:700}
+.package__install{font-family:Inconsolata,monospace;font-size:.85rem;background:#f3f4f6;color:#36363c;padding:10px 14px;border-radius:4px;margin:10px 0 12px;overflow-x:auto;border-left:3px solid #007bff}
+.package__install code{background:transparent;padding:0;color:inherit}
+.package__links{display:flex;flex-wrap:wrap;gap:18px;margin-bottom:14px}
+.package__links .arrow-link{font-size:.9rem}
+body.night .package__install{background:#222b3a;color:#e7e7e7;border-left-color:#4dabff}
+body.night .packages .project__name{color:#e7e7e7}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@ layout: default
   {% include background.html %}
   {% include experience.html %}
   {% include skills.html %}
+  {% include packages.html %}
   {% include projects.html %}
   {% include footer.html %}
   {% include top-button.html %}


### PR DESCRIPTION
Adds a dedicated **"Published"** section to the homepage for PyPI / shipped artifacts, separate from the generic GitHub-only "Projects" list.

## What

- New `_data/packages.yml` — one entry per published package. Fields: `name`, `description`, `install`, `links: [{label, url}]`, `used: [{thing}]`.
- New `_includes/packages.html` — renders each package as a card with:
  - install command in a monospace code block,
  - prominent **PyPI** and **GitHub** links,
  - existing `.project__used__item` chips for the tech stack.
- `index.html` — includes the new section above `projects.html`.
- `_data/projects.yml` — `azkv-ssh-fetch` removed (it now lives in `packages.yml`).
- `css/main.css` — ~10 lines for the install code block, link row, and dark-mode treatment. Reuses existing `.section`, `.project`, and `.project__used__item` classes.

## Why

Distributing a tool on PyPI is a meaningfully different signal than "here's a GitHub repo." A dedicated **Published** section makes that distinction visible at a glance and gives future shipped packages an obvious home — no template changes needed when tool #2 lands.

## Preview

| Light mode | Dark mode |
|---|---|
| New section appears between **Skills** and **Projects**, with the install snippet in a light-grey code block + blue left rule. | Code block flips to dark navy with the `#4dabff` accent already used elsewhere in night mode. |

## First entry

- **azkv-ssh-fetch** v0.1.1 — published 2026-06-22 — `pipx install azkv-ssh-fetch` — links to https://pypi.org/project/azkv-ssh-fetch/ and the GitHub repo.
