### PR TITLE
feat: add /writing/ section with first post stub (VMSS SSH keys + Key Vault)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,18 @@ keep_files:
 
 plugins:
   - jekyll-sitemap
+  - jekyll-feed
+  - jekyll-seo-tag
+
+# Permalink for posts: /writing/<slug>/
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: post
+      permalink: /writing/:slug/
+
+# RSS feed (jekyll-feed)
+feed:
+  path: feed.xml

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,7 @@
 <title>{{ site.title }}</title>
 <link rel="canonical" href="{{ site.url }}{{ page.url }}">
 <link rel="icon" type="image/png" href="{{site.logo}}" hreflang="en-us">
+<link rel="alternate" type="application/rss+xml" title="Naeem Hossain &mdash; Writing" href="{{ site.url }}/feed.xml">
 <meta property="og:title" content="{{site.title}}" />
 <meta property="og:description" content="{{site.description}}" />
 <meta property="og:type" content="website" />

--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -40,6 +40,11 @@
     <span>
       <a href="mailto:naeemhossain.mail@gmail.com" target="_blank" class="highlight-link">NaeemHossain.mail@gmail.com</a>
     </span>
+    {% if site.posts.size > 0 %}
+    <span class="intro__writing-link">
+      &middot; <a href="/writing/" class="highlight-link">Writing</a>
+    </span>
+    {% endif %}
   </h3>
   <!-- <div class='li'> -->
     <footer class="footer">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,57 @@
+---
+layout: default
+---
+<article class="section writing-post">
+  <div class="section__title">{{ page.date | date: "%b %Y" }}</div>
+  <div class="section__content">
+    <header class="writing-post__header">
+      <h1 class="writing-post__title">{{ page.title }}</h1>
+      {% if page.subtitle %}
+      <p class="writing-post__subtitle">{{ page.subtitle }}</p>
+      {% endif %}
+      <p class="writing-post__meta">
+        <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+        {% if page.reading_time %} &middot; {{ page.reading_time }} min read{% endif %}
+        {% if page.tags %}
+        <span class="writing-post__tags">
+          {% for tag in page.tags %}<span class="writing-post__tag">{{ tag }}</span>{% endfor %}
+        </span>
+        {% endif %}
+      </p>
+    </header>
+
+    <div class="writing-post__body">
+      {{ content }}
+    </div>
+
+    <nav class="writing-post__nav">
+      <a href="/writing/" class="arrow-link">All writing</a>
+      <a href="/" class="arrow-link">Back home</a>
+    </nav>
+  </div>
+</article>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | jsonify }},
+  "description": {{ page.description | default: site.description | jsonify }},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "dateModified": "{{ page.date | date_to_xmlschema }}",
+  "author": {
+    "@type": "Person",
+    "name": "Naeem Hossain",
+    "url": "{{ site.url }}"
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": "Naeem Hossain",
+    "url": "{{ site.url }}"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ site.url }}{{ page.url }}"
+  }
+}
+</script>

--- a/_posts/2026-06-22-vmss-ssh-keys-belong-in-keyvault.md
+++ b/_posts/2026-06-22-vmss-ssh-keys-belong-in-keyvault.md
@@ -1,0 +1,109 @@
+---
+title: "Why your VMSS SSH keys belong in Key Vault (and how to set it up in CDKTF)"
+subtitle: "Stop emailing public keys around. Generate, store, and grant — all from Terraform."
+description: "A practical CDKTF walkthrough for managing VMSS SSH access through Azure Key Vault and Bastion, plus the operator tool that uses it daily."
+date: 2026-06-22
+tags: [azure, terraform, cdktf, key-vault, bastion, vmss]
+reading_time: 8
+---
+
+> **TL;DR** &mdash; The right model for human SSH access to a Linux fleet on Azure is:
+> generate the keypair inside Terraform, store the private key in Key Vault, grant
+> humans `Key Vault Secrets User` via RBAC, and have them connect through Azure
+> Bastion. This post walks through the CDKTF wiring and shares
+> [`azkv-ssh-fetch`](https://pypi.org/project/azkv-ssh-fetch/) &mdash; a CLI that
+> turns the operator side of this pattern into a single command.
+
+## The "upload my public key" antipattern
+
+> *<!-- TODO: 2-3 paragraphs on the failure mode. Story about somebody emailing
+> their pubkey in Slack, the operator pasting it into the wrong VMSS, the
+> rotation nightmare that follows. Hint: every fresh engineer asks for this.
+> -->*
+
+## The right model in one diagram
+
+> *<!-- TODO: ASCII or simple mermaid diagram showing:
+>   Terraform → tls_private_key + azurerm_key_vault_secret
+>   Human → RBAC (Key Vault Secrets User) → KV secret → akf fetch
+>   Human → Azure Bastion → VMSS (port 22)
+> Key insight: the private key is never in source control, never in chat,
+> never on a workstation longer than needed.
+> -->*
+
+## Minimal CDKTF snippet
+
+> *<!-- TODO: ~30 lines of TypeScript showing:
+>   - generating tls_private_key
+>   - writing public key to vmss admin_ssh_key
+>   - writing private key to KV as a secret with content_type 'application/x-pem-file'
+>   - role_assignment block granting a group 'Key Vault Secrets User'
+> Keep it copy-paste-able. Real names, masked subs.
+> -->*
+
+```typescript
+// TODO: paste production-shaped snippet here.
+// Replace with your actual stack name + group object ID.
+```
+
+## What this buys you
+
+- **No key sprawl** &mdash; one private key per VMSS, lives in one place.
+- **Auditable access** &mdash; every `get-secret` call shows up in KV diagnostic logs with the user identity.
+- **Rotation is `terraform apply`** &mdash; bump the `tls_private_key` resource, re-run, done.
+- **PIM-compatible** &mdash; the role assignment can be marked PIM-eligible so humans elevate to access the key just-in-time.
+- **No shared keys in puppet/ansible** &mdash; the only thing in config management is the public key fingerprint, if anything.
+
+## The operator side: `akf`
+
+> *<!-- TODO: 2-3 paragraphs introducing the tool. Note that the post +
+> the tool are intentionally complementary &mdash; post explains the infra
+> pattern, tool removes the daily-driver friction.
+> -->*
+
+The operator workflow described above used to be a six-line shell snippet that
+every engineer re-typed (and got wrong) every time. I wrote
+[`azkv-ssh-fetch`](https://pypi.org/project/azkv-ssh-fetch/) to remove the
+boilerplate:
+
+```bash
+pipx install azkv-ssh-fetch
+
+# Find the SSH-shaped secrets in a vault
+akf list --vault prod-myteam-kv
+
+# Pull a key to ~/.ssh/<name> with mode 0600 (atomic)
+akf fetch --vault prod-myteam-kv my-vmss-ssh
+
+# Fetch + Bastion SSH in one command (key is shredded on disconnect by default)
+akf connect \
+  --vault prod-myteam-kv \
+  --secret my-vmss-ssh \
+  --bastion my-bastion --bastion-rg my-bastion-rg \
+  --target-id "/subscriptions/.../virtualMachineScaleSets/my-vmss/virtualMachines/0"
+```
+
+Source: [github.com/NaeemH/azkv-ssh-fetch](https://github.com/NaeemH/azkv-ssh-fetch) &middot; License: MIT.
+
+## Gotchas
+
+> *<!-- TODO: bulleted list. Drafts:
+>   - KV name length cap (24 chars) bites when you template names
+>   - Bastion *Standard* SKU minimum for native-client tunneling
+>   - VMSS image must have password auth disabled or this whole model is theater
+>   - Don't store the private key with content_type other than 'application/x-pem-file' — KV will let you, but tools may not filter it
+>   - SIG image generation mismatch (Gen1 vs Gen2) — separate post material
+> -->*
+
+## Further reading
+
+- [Azure Bastion native client](https://learn.microsoft.com/en-us/azure/bastion/connect-native-client-windows)
+- [Key Vault RBAC guide](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide)
+- [Terraform `tls_private_key`](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)
+- [CDKTF docs](https://developer.hashicorp.com/terraform/cdktf)
+
+---
+
+*Found a mistake or want to discuss? Open an issue at
+[`NaeemH/azkv-ssh-fetch`](https://github.com/NaeemH/azkv-ssh-fetch/issues) or
+ping me on [LinkedIn](https://www.linkedin.com/in/naeem-hossain).*

--- a/css/main.css
+++ b/css/main.css
@@ -17,3 +17,43 @@ body.night .intro__currently .currently-label{color:#4dabff}
 .package__links .arrow-link{font-size:.9rem}
 body.night .package__install{background:#222b3a;color:#e7e7e7;border-left-color:#4dabff}
 body.night .packages .project__name{color:#e7e7e7}
+
+/* Writing / blog post styles (added 2026-06-22) */
+.writing-list{list-style:none;padding:0;margin:0}
+.writing-list__item{margin-bottom:32px}
+.writing-list__item:last-of-type{margin-bottom:0}
+.writing-list__title{font-weight:700;font-size:1.1rem;display:inline-block;margin-bottom:4px}
+.writing-list__meta{font-family:Inconsolata,monospace;font-size:.8rem;color:#666;margin:0 0 6px}
+.writing-list__desc{font-size:.95rem;margin:0}
+.writing-index__feed{margin-top:30px;font-size:.85rem}
+body.night .writing-list__meta{color:#9a9ab0}
+.writing-post__header{margin-bottom:30px;padding-bottom:20px;border-bottom:1px solid #e5e5e5}
+body.night .writing-post__header{border-bottom-color:#2a3344}
+.writing-post__title{font-size:1.8rem;font-weight:700;margin:0 0 8px;line-height:1.25}
+.writing-post__subtitle{font-size:1.05rem;font-weight:300;color:#666;margin:0 0 14px;line-height:1.4}
+body.night .writing-post__subtitle{color:#afafbf}
+.writing-post__meta{font-family:Inconsolata,monospace;font-size:.8rem;color:#666;margin:0}
+body.night .writing-post__meta{color:#9a9ab0}
+.writing-post__tags{margin-left:8px}
+.writing-post__tag{display:inline-block;margin-right:6px;padding:1px 7px;border-radius:3px;color:#007bff;border:1px solid #007bff;font-size:.7rem;letter-spacing:1px;text-transform:uppercase}
+body.night .writing-post__tag{color:#4dabff;border-color:#4dabff}
+.writing-post__body{font-size:1rem;line-height:1.7}
+.writing-post__body h2{font-size:1.3rem;font-weight:700;margin-top:36px;margin-bottom:14px;color:#36363c}
+body.night .writing-post__body h2{color:#e7e7e7}
+.writing-post__body h3{font-size:1.1rem;font-weight:700;margin-top:28px;margin-bottom:10px}
+.writing-post__body p{margin:0 0 18px}
+.writing-post__body ul,.writing-post__body ol{padding-left:24px;margin:0 0 18px}
+.writing-post__body li{margin-bottom:6px}
+.writing-post__body a{color:#007bff;font-weight:400;text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px}
+body.night .writing-post__body a{color:#4dabff}
+.writing-post__body code{font-family:Inconsolata,monospace;font-size:.9em;background:#f3f4f6;color:#36363c;padding:1px 6px;border-radius:3px}
+body.night .writing-post__body code{background:#222b3a;color:#e7e7e7}
+.writing-post__body pre{background:#f3f4f6;color:#36363c;padding:14px 16px;border-radius:4px;overflow-x:auto;border-left:3px solid #007bff;font-size:.85rem;line-height:1.5;margin:0 0 18px}
+.writing-post__body pre code{background:transparent;padding:0;font-size:inherit}
+body.night .writing-post__body pre{background:#222b3a;color:#e7e7e7;border-left-color:#4dabff}
+.writing-post__body blockquote{margin:0 0 18px;padding:10px 18px;border-left:3px solid #007bff;background:#f9fafb;color:#555;font-style:italic}
+body.night .writing-post__body blockquote{background:#1c2230;color:#cfcfd9;border-left-color:#4dabff}
+.writing-post__body hr{border:none;border-top:1px solid #e5e5e5;margin:30px 0}
+body.night .writing-post__body hr{border-top-color:#2a3344}
+.writing-post__nav{margin-top:40px;padding-top:20px;border-top:1px solid #e5e5e5;display:flex;gap:30px;flex-wrap:wrap}
+body.night .writing-post__nav{border-top-color:#2a3344}

--- a/writing.html
+++ b/writing.html
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Writing
+permalink: /writing/
+---
+<section class="section writing-index">
+  <div class="section__title">Writing</div>
+  <div class="section__content">
+    {% if site.posts.size == 0 %}
+    <p>No posts yet. Subscribe to the <a href="/feed.xml" class="arrow-link">RSS feed</a> for new pieces.</p>
+    {% else %}
+    <ul class="writing-list">
+      {% for post in site.posts %}
+      <li class="writing-list__item">
+        <a href="{{ post.url }}" class="writing-list__title">{{ post.title }}</a>
+        <p class="writing-list__meta">
+          <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
+        </p>
+        {% if post.description %}
+        <p class="writing-list__desc">{{ post.description }}</p>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+    <p class="writing-index__feed">
+      <a href="/feed.xml" class="arrow-link">RSS feed</a>
+    </p>
+    {% endif %}
+  </div>
+</section>


### PR DESCRIPTION
## Summary
Scaffolds the site's writing/blog section and lands the first post as an outline-only stub. Establishes the URL shape (`/writing/:slug/`), feed (`/feed.xml`), and post layout so future posts are zero-friction to drop into `_posts/`.

## Changes
- **New layout**: `_layouts/post.html` — title, date, optional subtitle/tags/reading-time, prose body, BlogPosting JSON-LD, back-nav.
- **New page**: `writing.html` → `/writing/` index listing all posts + RSS link.
- **New post stub**: `_posts/2026-06-22-vmss-ssh-keys-belong-in-keyvault.md` — "Why your VMSS SSH keys belong in Key Vault (and how to set it up in CDKTF)". Headings, TL;DR, gotchas list, and the companion-tool section linking to [`azkv-ssh-fetch`](https://pypi.org/project/azkv-ssh-fetch/) are in place. Prose blocks marked with `TODO` blockquotes for fill-in.
- **`_config.yml`**: enable `jekyll-feed` + `jekyll-seo-tag` plugins; add `defaults` block setting `permalink: /writing/:slug/` and `layout: post` for everything under `_posts/`.
- **`_includes/head.html`**: add `<link rel="alternate" type="application/rss+xml">` so feed readers auto-discover.
- **`_includes/intro.html`**: surface "Writing" link beside the contact line — only renders when `site.posts.size > 0`, so the link won't appear empty before posts ship.
- **`css/main.css`**: append minimal styles for `.writing-list*` and `.writing-post*` (light + night themes, using the existing `#4dabff` night-mode accent).

## Verification
- No Gemfile in the repo → site runs on GitHub Pages default gem, which includes `jekyll-feed`/`jekyll-seo-tag`/`jekyll-sitemap` out of the box, so no `bundle install` step needed.
- Locally: no bundler installed, so this relies on the GitHub Pages build. Will verify post renders at `https://naeemh.github.io/writing/vmss-ssh-keys-belong-in-keyvault/` after merge.
- The "Writing" link in `intro.html` is gated on `site.posts.size > 0` so the homepage is unchanged for any environment without posts.

## Follow-ups (not in this PR)
- Fill in the prose blocks in the post (currently outline-only with `TODO` blockquotes).
- Add a real CDKTF code snippet in the post.
- Consider an "Articles" or "Blog" link in the bottom footer as well once the section has 2+ posts.
