### PR TITLE
feat(packages): add avnm-pool-cidr to published-work list

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -12,3 +12,18 @@
     - thing: Azure SDK
     - thing: Azure Key Vault
     - thing: Azure Bastion
+
+- name: avnm-pool-cidr
+  description: Python CLI that picks the next free CIDR prefix from an Azure Virtual Network Manager IPAM pool, plus subcommands to list pool reservations and report per-prefix utilization. Removes the manual portal arithmetic.
+  install: pipx install avnm-pool-cidr
+  links:
+    - label: PyPI
+      url: https://pypi.org/project/avnm-pool-cidr/
+    - label: GitHub
+      url: https://github.com/NaeemH/avnm-pool-cidr
+  used:
+    - thing: Python
+    - thing: Typer
+    - thing: Azure CLI
+    - thing: Azure Virtual Network Manager
+    - thing: IPAM


### PR DESCRIPTION
## Summary
Adds a second entry to `_data/packages.yml` for `avnm-pool-cidr` (v0.1.0, [PyPI](https://pypi.org/project/avnm-pool-cidr/) / [GitHub](https://github.com/NaeemH/avnm-pool-cidr)), now that it shipped today via OIDC trusted publishing.

## Why
Closes the "Published" section's first multi-entry rendering — the template (`_includes/packages.html`) already iterates `site.data.packages`, so this is purely a YAML data change. Zero template / CSS / layout edits needed.

## Verification
- `pipx install avnm-pool-cidr && apc --version` -> `avnm-pool-cidr 0.1.0` ✅
- PyPI page live: https://pypi.org/project/avnm-pool-cidr/
- Tech chips match the project's actual dependency surface (Python, Typer, Azure CLI, Azure Virtual Network Manager, IPAM).
