### PR TITLE
Refresh homepage: intro/background/experience content

### DIFF
--- a/_data/certifications.yaml
+++ b/_data/certifications.yaml
@@ -1,6 +1,15 @@
-certifications:
-  - item: "Microsoft Certified: Azure Fundamentals (AZ-900)"
-  - item: "Microsoft Certified: Azure Administrator Associate (AZ-104)"
-  - item: Sumo Logic Certified Fundamentals
-  - item: Sumo Logic Certified Power User
-  - item: Sumo Logic Certified Power Admin
+groups:
+  - provider: "Microsoft Certified"
+    items:
+      - name: "Azure Administrator Associate (AZ-104)"
+        url: "https://learn.microsoft.com/en-us/credentials/certifications/azure-administrator/"
+      - name: "Azure Fundamentals (AZ-900)"
+        url: "https://learn.microsoft.com/en-us/credentials/certifications/azure-fundamentals/"
+  - provider: "Sumo Logic Certified"
+    items:
+      - name: "Power Admin"
+        url: "https://www.sumologic.com/learn/certifications/"
+      - name: "Power User"
+        url: "https://www.sumologic.com/learn/certifications/"
+      - name: "Fundamentals"
+        url: "https://www.sumologic.com/learn/certifications/"

--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -2,49 +2,33 @@
   url: https://www.microsoft.com/en-us/ai
   time: June 2022 - Present
   position: Senior Software Engineer
+  location: New York, NY
   description:
-    - Lead reliability and automation for a 10k+ machine global ad-serving fleet across multiple Azure regions
-    - Author Terraform / CDKTF infrastructure-as-code that provisions and lifecycles VMSS, AKS, networking, and storage primitives
-    - Drive incident response and capacity remediation playbooks, partnering with Azure capacity teams on zonal vs regional allocator strategies
-    - Build internal tooling for fleet observability (Geneva, Prometheus) and AI-assisted runbook execution (Copilot, Claude, GPT)
-    - Mentor junior engineers and shape operational standards through code reviews and design docs
+    - Author org-wide Terraform / CDKTF configs that handle 95% of the Azure lifecycle (VMSS, network, storage, etc.)
+    - Built an MCP agent that handles 100% of critical on-prem infrastructure investigations (~10k hosts)
+    - Hold training sessions to onboard team members to full ownership in the Azure environment
+    - Develop &amp; deploy internal observability dashboards (Geneva) for the entire org
+    - Estimate costs, plan budgets, &amp; manage Azure capacity for org leadership
 
 - company: Xandr
   url: https://www.xandr.com/
-  time: February 2021 - June 2022
-  position: System Operations Engineer II
+  time: March 2019 - June 2022
+  position: "Associate System Operations Engineer &rarr; System Operations Engineer II"
+  location: New York, NY
   description:
-    - Scaled critical ad-serving systems through the Microsoft acquisition transition, migrating Puppet-managed infra toward declarative IaC
-    - Designed and rolled out monitoring + alerting for high-throughput pipelines using Sumo Logic and PagerDuty
-    - Automated repetitive ops toil (cluster rebuilds, capacity scaling, security patching), reducing weekly on-call interrupts
-    - Led postmortems and contributed to multi-team reliability initiatives around config drift and deploy safety
-    - Onboarded and mentored newer engineers on the team's CentOS / Ansible / Puppet stack
-
-- company: Xandr
-  url: https://www.xandr.com/
-  time: January 2020 - February 2021
-  position: System Operations Engineer I
-  description:
-    - Owned the health of thousands of Linux hosts powering real-time bidding
-    - Authored Puppet and Ansible modules for repeatable, drift-free configuration management
-    - Participated in the 24/7 on-call rotation, responding to incidents across compute, network, and storage layers
-    - Built lightweight Python and Bash tooling to streamline daily ops tasks
-    - Contributed to migration projects moving services off legacy CentOS toward modern host stacks
-
-- company: Xandr
-  url: https://www.xandr.com/
-  time: March 2019 - January 2020
-  position: Associate System Operations Engineer
-  description:
-    - Ramped on a large-scale ad-tech operations stack covering compute, monitoring, and configuration management
-    - Triaged production issues across geographically distributed datacenters during shadow and active on-call shifts
-    - Wrote ops scripts and small tools to accelerate common manual workflows
-    - Contributed to runbooks and onboarding documentation as the team grew
+    - Deployed &amp; maintained platform infrastructure for Microsoft Advertising &amp; Netflix Ad-Serving
+    - Built Python tools &amp; libraries to automate vault secret management, live-traffic shifts, &amp; server migrations
+    - Rebuilt several legacy (10+ yr) RHEL-based applications to full functionality on recent Ubuntu distros
+    - Leveraged 200+ hours of on-call experience to resolve client-facing outages and handle postmortems
+    - Migrated team observability &amp; alerting infrastructure from a variety of on-prem sources to IcM
+    - Planned &amp; enabled hyperthreading on 15+ Kubernetes clusters &mdash; optimized CPU / Memory by ~30%
+    - Migrated team communications &amp; automation from Slack to Microsoft Teams
 
 - company: RUniteCS
   url: https://www.linkedin.com/company/runitecs/about/
   time: Sep 2017 - Aug 2019
   position: Ambassador
+  location: New Brunswick, NJ
   description:
     - Represented women-in-CS initiatives at Rutgers, organizing community events and tech workshops
     - Mentored new students through their first CS coursework, hosting study sessions and code reviews
@@ -54,25 +38,28 @@
   url: https://www.linkedin.com/company/appnexus/
   time: Jun 2018 - Aug 2018
   position: System Operations Intern
+  location: New York, NY
   description:
-    - Built internal tooling for the systems operations team in Python and Bash
-    - Shadowed on-call rotation for a large-scale ad-tech infrastructure across multiple datacenters
-    - Delivered an end-of-summer project improving monitoring / automation workflows
+    - Built internal tools using Python / Flask, uWSGI, and NGINX to reduce traffic shifting time by 50%
+    - Engaged in infrastructure maintenance, capacity planning, and emergency response
+    - Used Puppet, Kubernetes / Docker, and NGINX load balancers to manage infrastructure
 
-- company: Prudential Financial
+- company: Prudential Experimental Laboratory
   url: https://www.prudential.com/
   time: May 2017 - Aug 2017
-  position: Software Engineering Intern
+  position: Software Development Intern
+  location: Newark, NJ
   description:
-    - Contributed full-stack features to enterprise web applications on the MEAN stack (MongoDB, Express, Angular, Node.js)
-    - Built and tested production-bound components shipped to internal users
-    - Participated in agile ceremonies (standups, sprint planning, retros) on a full-time delivery team
+    - Developed applications with the MEAN stack (MongoDB, Express.io, AngularJS, Node.js)
+    - Successfully pitched minimal viable products to company leadership
+    - Built data visualization applications with D3 and Tableau
 
-- company: Viacom
+- company: Viacom Media Networks
   url: https://www.viacomcbs.com/
   time: Jan 2016 - Sep 2016
-  position: Software Engineering Intern
+  position: Software Development Intern
+  location: New York, NY
   description:
-    - Built features for internal media-pipeline tooling on the MERN stack (MongoDB, Express, React, Node.js)
-    - Worked across full-stack tickets supporting content production workflows
-    - Participated in design discussions and code reviews alongside permanent engineering staff
+    - Cooperated with Apple to implement deep-linking and Siri into Apple TV applications
+    - Developed Viacom's iOS / Apple TV applications using both Swift and TVML
+    - Used Node.js to write and implement content APIs

--- a/_data/now.yml
+++ b/_data/now.yml
@@ -1,4 +1,4 @@
 # What I'm focused on right now.
 # Update this whenever — drives the "Currently" line on the homepage.
 # Keep it to a single sentence.
-currently: "Building AVNM-managed network topology and AI-assisted runbooks at Microsoft."
+currently: "Building Microsoft AI tooling to migrate an entire company's on-premise applications &amp; infrastructure into Azure."

--- a/_includes/background.html
+++ b/_includes/background.html
@@ -11,30 +11,40 @@
     </p>
 
     <p>
-      As a systems engineer, I oversee a fleet of 10k+ machines globally, identify &amp; automate technical debt, scale our systems to tackle extreme workloads, and write lots of config files &mdash; here are a few certifications I've earned along the way:
-      <ul class="a">
-        <li>
-          <a class="underline-link" href="https://learn.microsoft.com/en-us/credentials/certifications/azure-administrator/" target="_blank">Microsoft Certified: Azure Administrator Associate (AZ-104)</a>
-        </li>
-        <li>
-          <a class="underline-link" href="https://learn.microsoft.com/en-us/credentials/certifications/azure-fundamentals/" target="_blank">Microsoft Certified: Azure Fundamentals (AZ-900)</a>
-        </li>
-        <li>
-          <a class="underline-link" href="https://www.sumologic.com/learn/certifications/" target="_blank">Sumo Logic Certified Power Admin</a>
-        </li>
-        <li>
-          <a class="underline-link" href="https://www.sumologic.com/learn/certifications/" target="_blank">Sumo Logic Certified Power User</a>
-        </li>
-        <li>
-          <a class="underline-link" href="https://www.sumologic.com/learn/certifications/" target="_blank">Sumo Logic Certified Fundamentals</a>
-        </li>
-      </ul>
+      As a platform engineer, I oversee a fleet of ~30k Azure virtual instances, use AI tooling to automate solutions, and manage the Terraform infrastructure for an entire org &mdash; here are a few certifications I've earned along the way:
     </p>
+    <ul class="certifications">
+      <li>
+        Microsoft Certified:
+        <ul>
+          <li>
+            <a class="underline-link" href="https://learn.microsoft.com/en-us/credentials/certifications/azure-administrator/" target="_blank">Azure Administrator Associate (AZ-104)</a>
+          </li>
+          <li>
+            <a class="underline-link" href="https://learn.microsoft.com/en-us/credentials/certifications/azure-fundamentals/" target="_blank">Azure Fundamentals (AZ-900)</a>
+          </li>
+        </ul>
+      </li>
+      <li>
+        Sumo Logic Certified:
+        <ul>
+          <li>
+            <a class="underline-link" href="https://www.sumologic.com/learn/certifications/" target="_blank">Power Admin</a>
+          </li>
+          <li>
+            <a class="underline-link" href="https://www.sumologic.com/learn/certifications/" target="_blank">Power User</a>
+          </li>
+          <li>
+            <a class="underline-link" href="https://www.sumologic.com/learn/certifications/" target="_blank">Fundamentals</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
 
 
 
     <p>
-      <strong>When I'm not in front of a computer screen</strong>, I'm probably reading, cooking some delicious food, or helping with community-driven tech efforts!
+      <strong>When I'm not in front of a computer screen</strong>, I'm probably cooking or adventuring!
     </p>
   </div>
 </section>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,6 +19,12 @@
       <img src="{{site.baseurl}}/img/social/{{link.title}}.svg" alt="{{link.title}}" width="22" height="22">
     </a>
     {% endfor %}
+    {% if site.posts.size > 0 %}
+    <a href="{{site.baseurl}}/writing/" title="writing">
+      <span class="text">writing</span>
+      <img src="{{site.baseurl}}/img/social/writing.svg" alt="writing" width="22" height="22">
+    </a>
+    {% endif %}
   </div>
 </footer>
 </div>

--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -40,11 +40,6 @@
     <span>
       <a href="mailto:naeemhossain.mail@gmail.com" target="_blank" class="highlight-link">NaeemHossain.mail@gmail.com</a>
     </span>
-    {% if site.posts.size > 0 %}
-    <span class="intro__writing-link">
-      &middot; <a href="/writing/" class="highlight-link">Writing</a>
-    </span>
-    {% endif %}
   </h3>
   <!-- <div class='li'> -->
     <footer class="footer">
@@ -55,6 +50,12 @@
           <img src="{{site.baseurl}}/img/social/{{link.title}}.svg" alt="{{link.title}}" width="22" height="22">
         </a>
         {% endfor %}
+        {% if site.posts.size > 0 %}
+        <a href="{{site.baseurl}}/writing/" title="writing">
+          <span class="text">writing</span>
+          <img src="{{site.baseurl}}/img/social/writing.svg" alt="writing" width="22" height="22">
+        </a>
+        {% endif %}
       </div>
     </footer>
   <!--  </div> -->

--- a/img/social/writing.svg
+++ b/img/social/writing.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="22" height="22" aria-hidden="true">
+  <!-- Feather-style pencil/edit icon for the Writing link -->
+  <path d="M12 20h9"/>
+  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+</svg>


### PR DESCRIPTION
# Homepage content refresh

Content-only refresh of the homepage data + includes. No visual / layout work in this PR.

## What changed

**Currently line** — `_data/now.yml`
- Reflects the on-prem → Azure migration tooling work.

**Intro + footer / Writing link** — `_includes/intro.html`, `_includes/footer.html`, `img/social/writing.svg`
- Removed the inline Writing link from the `Get in touch:` contact row.
- Moved it down into the same social row as Resume / GitHub / LinkedIn / Email so the homepage has a single, consistent set of links along the bottom.
- Both `footer__links` blocks (the one inside `intro.html` and the standalone `footer.html`) now append a gated Writing entry after the `site.social` loop. The link only renders when `site.posts.size > 0`, matching the old gating.
- New `img/social/writing.svg` (feather-style pencil icon, `currentColor`-aware so it picks up the existing theme color, sized at 22×22 to match the other social icons).

**Background** — `_includes/background.html`
- Replaced the old "As a systems engineer, I oversee a fleet of 10k+ machines globally…" paragraph with the new platform-engineer phrasing focused on the ~30k Azure VM fleet, AI tooling, and org-wide Terraform.
- Restructured the certifications list from a flat `<ul>` into grouped sub-bullets:
  - **Microsoft Certified:** Azure Administrator Associate (AZ-104), Azure Fundamentals (AZ-900)
  - **Sumo Logic Certified:** Power Admin, Power User, Fundamentals
- Tightened the closing line from the older "reading, cooking some delicious food, or helping with community-driven tech efforts" to **"cooking or adventuring"**.

**Certifications data** — `_data/certifications.yaml`
- Restructured to mirror the grouped format used in `background.html`. Still not consumed by any template, but kept consistent so it's accurate if/when something starts iterating it.

**Experience** — `_data/experience.yml`
- **Microsoft AI** — rewrote the five bullets to:
  - Author org-wide Terraform / CDKTF configs that handle 95% of the Azure lifecycle (VMSS, network, storage, etc.)
  - Built an MCP agent that handles 100% of critical on-prem infrastructure investigations (~10k hosts)
  - Hold training sessions to onboard team members to full ownership in the Azure environment
  - Develop & deploy internal observability dashboards (Geneva) for the entire org
  - Estimate costs, plan budgets, & manage Azure capacity for org leadership
- **Xandr** — consolidated the three separate entries (Associate SOE, SOE I, SOE II) into a single entry covering **March 2019 – June 2022**, with the title showing the progression `Associate System Operations Engineer → System Operations Engineer II` and the new bullet set (Microsoft Advertising & Netflix Ad-Serving, Python vault/traffic-shift tooling, RHEL→Ubuntu rebuilds, 200+ hours on-call, on-prem→IcM observability, hyperthreading on 15+ k8s clusters, Slack→Teams migration).
- **Internships** — restored the historical metric-driven bullets:
  - **AppNexus** (Jun 2018 – Aug 2018, NYC) — Python/Flask/uWSGI/NGINX traffic-shifting tool (50% reduction), capacity planning & emergency response, Puppet / Kubernetes / Docker.
  - **Prudential Experimental Laboratory** (May 2017 – Aug 2017, Newark NJ) — MEAN stack (MongoDB, Express.io, AngularJS, Node.js), MVP pitches to leadership, D3 + Tableau dashboards.
  - **Viacom Media Networks** (Jan 2016 – Sep 2016, NYC) — Apple deep-linking + Siri integration on Apple TV apps, Swift + TVML, Node.js content APIs.
- Added a `location:` field on every entry. Not rendered today but ready for the future Brittany-Chiang-style tabbed redesign.

## Out of scope (future work)

The Experience section is intentionally **not** restructured visually in this PR. The plan is to follow up with a separate PR that rebuilds `_includes/experience.html` (and adds CSS / minimal JS) into a tabbed layout similar to brittanychiang.com's `02. Where I've Worked` — vertical company tabs on the left, role + bullets on the right, driven by the same `experience.yml` entries (including the new `location` field).

## Verification

- All four YAML files (`now.yml`, `experience.yml`, `certifications.yaml`, `_config.yml`) parse cleanly with `yaml.safe_load`.
- Liquid templating in `intro.html`, `footer.html`, `background.html` uses the same patterns already in the file (gated `{% if site.posts.size > 0 %}` for the Writing link, mirroring the previous intro-line gate).
- HTML entities (`&amp;`, `&mdash;`, `&rarr;`) preserved consistently across the changed files.

Branch: `nh/content-refresh-2026-06`
