### PR TITLE
Tabbed Experience section + Currently refresh + Published arrow fix

### DIFF
--- a/_data/now.yml
+++ b/_data/now.yml
@@ -1,4 +1,4 @@
 # What I'm focused on right now.
 # Update this whenever — drives the "Currently" line on the homepage.
 # Keep it to a single sentence.
-currently: "Building Microsoft AI tooling to migrate an entire company's on-premise applications &amp; infrastructure into Azure."
+currently: "Microsoft AI | Building ai-powered systems to migrate an entire company's on-premise applications &amp; infrastructure into azure"

--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -1,28 +1,93 @@
 <section class="section experience">
   <div class="section__title">Experience</div>
   <div class="section__content">
-    <div class="jobs">
-      {% for job in site.data.experience %}
-      <div class="job">
-        <div class="time-place">
-          <div class="job__company">
-            <a class="underline-link" href="{{job.url}}" target="_blank">{{job.company}}</a>
-          </div>
-          <div class="job__time">{{job.time}}</div>
+    <div class="exp-tabs" data-exp-tabs>
+      <ul class="exp-tabs__list" role="tablist" aria-label="Companies I've worked at">
+        {% for job in site.data.experience %}
+        <li role="presentation" class="exp-tabs__list-item">
+          <button id="exp-tab-{{forloop.index0}}"
+                  class="exp-tabs__tab{% if forloop.first %} is-active{% endif %}"
+                  role="tab"
+                  type="button"
+                  aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
+                  aria-controls="exp-panel-{{forloop.index0}}"
+                  tabindex="{% if forloop.first %}0{% else %}-1{% endif %}">
+            {{ job.company }}
+          </button>
+        </li>
+        {% endfor %}
+      </ul>
+
+      <div class="exp-tabs__panels">
+        {% for job in site.data.experience %}
+        <div id="exp-panel-{{forloop.index0}}"
+             class="exp-tabs__panel{% if forloop.first %} is-active{% endif %}"
+             role="tabpanel"
+             aria-labelledby="exp-tab-{{forloop.index0}}"
+             tabindex="0">
+          <h3 class="exp-tabs__heading">
+            <span class="exp-tabs__position">{{ job.position }}</span>
+            <span class="exp-tabs__at"> &nbsp;@&nbsp; </span>
+            <a class="exp-tabs__company-link" href="{{job.url}}" target="_blank" rel="noopener">{{ job.company }}</a>
+          </h3>
+          <p class="exp-tabs__meta">
+            <span class="exp-tabs__time">{{ job.time }}</span>
+            {% if job.location %}<span class="exp-tabs__dot" aria-hidden="true"> &middot; </span><span class="exp-tabs__location">{{ job.location }}</span>{% endif %}
+          </p>
+          {% if job.description %}
+          <ul class="exp-tabs__bullets">
+            {% for bullet in job.description %}
+            <li>{{ bullet }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
         </div>
-        <div class="job__position">{{job.position}}</div>
-        {% if job.description %}
-        <ul class="job__description">
-          {% for bullet in job.description %}
-          <li>{{ bullet }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %}
+        {% endfor %}
       </div>
-      {% endfor %}
     </div>
-<!--
-    <a href="{{site.resume}}" target="_blank" class="arrow-link">View My Resume</a>
--->
   </div>
 </section>
+
+<script>
+  (function () {
+    // Progressive-enhancement: only enable tabbed UI when JS is on.
+    // No-JS users see all panels stacked.
+    var roots = document.querySelectorAll('[data-exp-tabs]');
+    roots.forEach(function (root) {
+      root.classList.add('exp-tabs--js');
+
+      var tabs = Array.prototype.slice.call(root.querySelectorAll('[role="tab"]'));
+      var panels = Array.prototype.slice.call(root.querySelectorAll('[role="tabpanel"]'));
+
+      function activate(index, setFocus) {
+        tabs.forEach(function (tab, i) {
+          var selected = i === index;
+          tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+          tab.setAttribute('tabindex', selected ? '0' : '-1');
+          tab.classList.toggle('is-active', selected);
+        });
+        panels.forEach(function (panel, i) {
+          panel.classList.toggle('is-active', i === index);
+        });
+        if (setFocus) tabs[index].focus();
+      }
+
+      tabs.forEach(function (tab, index) {
+        tab.addEventListener('click', function () { activate(index, false); });
+        tab.addEventListener('keydown', function (event) {
+          var key = event.key;
+          var last = tabs.length - 1;
+          var next = null;
+          if (key === 'ArrowDown' || key === 'ArrowRight') next = index === last ? 0 : index + 1;
+          else if (key === 'ArrowUp' || key === 'ArrowLeft') next = index === 0 ? last : index - 1;
+          else if (key === 'Home') next = 0;
+          else if (key === 'End') next = last;
+          if (next !== null) {
+            event.preventDefault();
+            activate(next, true);
+          }
+        });
+      });
+    });
+  })();
+</script>

--- a/css/main.css
+++ b/css/main.css
@@ -57,3 +57,58 @@ body.night .writing-post__body blockquote{background:#1c2230;color:#cfcfd9;borde
 body.night .writing-post__body hr{border-top-color:#2a3344}
 .writing-post__nav{margin-top:40px;padding-top:20px;border-top:1px solid #e5e5e5;display:flex;gap:30px;flex-wrap:wrap}
 body.night .writing-post__nav{border-top-color:#2a3344}
+
+/* Suppress trailing -> arrow on Package links (added 2026-06-22) */
+.package__links .arrow-link:after{display:none;content:none}
+
+/* Tabbed Experience section (Brittany-Chiang style; added 2026-06-22) */
+.experience .jobs{margin-bottom:0}
+.exp-tabs{display:block}
+.exp-tabs__list{list-style:none;padding:0;margin:0 0 30px;display:flex;overflow-x:auto;-webkit-overflow-scrolling:touch;border-bottom:1px solid #e5e5e5}
+.exp-tabs__list-item{margin:0}
+.exp-tabs__tab{font-family:inherit;font-size:.85rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#666;background:transparent;border:0;border-bottom:2px solid transparent;padding:14px 18px;cursor:pointer;white-space:nowrap;transition:color .2s ease-in-out,border-color .2s ease-in-out,background-color .2s ease-in-out;outline:none}
+.exp-tabs__tab:hover,.exp-tabs__tab:focus-visible{color:#007bff;background:rgba(0,123,255,0.06)}
+.exp-tabs__tab.is-active{color:#007bff;border-bottom-color:#007bff}
+.exp-tabs__panel{padding:4px 4px 24px}
+.exp-tabs__panel:not(:last-of-type){border-bottom:1px solid #f0f0f3;margin-bottom:20px;padding-bottom:32px}
+.exp-tabs__heading{margin:0 0 6px;font-size:1.1rem;font-weight:700;line-height:1.4}
+.exp-tabs__position{color:#36363c;font-weight:700}
+.exp-tabs__at{color:#666;font-weight:400}
+.exp-tabs__company-link{color:#007bff;font-weight:700}
+.exp-tabs__meta{font-family:Inconsolata,monospace;font-size:.85rem;color:#666;margin:0 0 14px}
+.exp-tabs__bullets{list-style:none;padding:0;margin:0}
+.exp-tabs__bullets li{position:relative;padding-left:24px;margin-bottom:8px;font-size:.95rem;line-height:1.5}
+.exp-tabs__bullets li:before{content:'';position:absolute;left:6px;top:.55em;width:8px;height:8px;border-right:2px solid #007bff;border-bottom:2px solid #007bff;transform:rotate(-45deg)}
+
+/* JS-enhanced view: vertical tab list on desktop, only active panel visible */
+@media screen and (min-width:769px){
+  .exp-tabs--js{display:flex;align-items:flex-start;gap:30px}
+  .exp-tabs--js .exp-tabs__list{flex-direction:column;flex-shrink:0;min-width:200px;max-width:260px;margin:0;border-bottom:none;border-left:1px solid #e5e5e5;overflow-x:visible}
+  .exp-tabs--js .exp-tabs__list-item{display:block}
+  .exp-tabs--js .exp-tabs__tab{display:block;width:100%;text-align:left;padding:12px 18px;border-bottom:0;border-left:2px solid transparent;margin-left:-1px}
+  .exp-tabs--js .exp-tabs__tab.is-active{border-bottom:0;border-left-color:#007bff}
+  .exp-tabs--js .exp-tabs__panels{flex:1;min-width:0}
+  .exp-tabs--js .exp-tabs__panel{display:none;padding:0}
+  .exp-tabs--js .exp-tabs__panel:not(:last-of-type){border-bottom:none;margin-bottom:0;padding-bottom:0}
+  .exp-tabs--js .exp-tabs__panel.is-active{display:block}
+}
+
+/* JS-enhanced view: horizontal tab strip on mobile */
+@media screen and (max-width:768px){
+  .exp-tabs--js .exp-tabs__panel{display:none;padding:0;border:0;margin:0}
+  .exp-tabs--js .exp-tabs__panel.is-active{display:block}
+}
+
+/* Dark-mode tweaks */
+body.night .exp-tabs__list{border-bottom-color:#2a3344}
+body.night .exp-tabs--js .exp-tabs__list{border-left-color:#2a3344;border-bottom:none}
+body.night .exp-tabs__tab{color:#9a9ab0}
+body.night .exp-tabs__tab:hover,body.night .exp-tabs__tab:focus-visible{color:#4dabff;background:rgba(77,171,255,0.08)}
+body.night .exp-tabs__tab.is-active{color:#4dabff;border-bottom-color:#4dabff}
+body.night .exp-tabs--js .exp-tabs__tab.is-active{border-left-color:#4dabff;border-bottom-color:transparent}
+body.night .exp-tabs__position{color:#e7e7e7}
+body.night .exp-tabs__at{color:#9a9ab0}
+body.night .exp-tabs__company-link{color:#4dabff}
+body.night .exp-tabs__meta{color:#9a9ab0}
+body.night .exp-tabs__bullets li:before{border-right-color:#4dabff;border-bottom-color:#4dabff}
+body.night .exp-tabs__panel:not(:last-of-type){border-bottom-color:#2a3344}


### PR DESCRIPTION
# Tabbed Experience section + Currently refresh + Published arrow fix

Three focused changes, off the latest content refresh:

## 1. `now.yml` — Currently line

Updated to:
> Microsoft AI | Building ai-powered systems to migrate an entire company's on-premise applications & infrastructure into azure

## 2. Tabbed Experience section (Brittany Chiang v4 style)

Rebuilt `_includes/experience.html` to match the [v4.brittanychiang.com](https://v4.brittanychiang.com/) `02. Where I've Worked` pattern.

**Layout**
- Desktop (≥ 769px): vertical list of company tabs on the left (`200–260px` rail with a left border + 2px accent indicator on the active tab), panel on the right.
- Mobile (< 769px): tab list collapses to a horizontal scrollable strip with a bottom-border indicator on the active tab.
- Each panel renders:
  - **Heading**: `Position @ Company` — company is a link in the accent color.
  - **Meta line**: monospace `time · location` (the `location:` field added in PR #10 now renders).
  - **Bullets**: rendered with a small accent-colored chevron marker (rotated 45° square-border).

**Accessibility**
- Full keyboard support — `↑/↓` and `←/→` walk tabs, `Home`/`End` jump to ends, focus follows the active tab.
- Full ARIA — `role="tablist"` on the `<ul>`, `role="tab"` on each `<button>` with `aria-selected` + `aria-controls` + `tabindex` management, `role="tabpanel"` on each panel with `aria-labelledby`.
- Focus styling uses `:focus-visible` so it shows up for keyboard users only.

**Progressive enhancement**
- Panels render stacked with all bullets visible when JavaScript is off — the tabbed-only view is gated on the `exp-tabs--js` class that the inline script adds on init. So no-JS readers (and screen-reader users in a non-JS context) get the full content; JS users get the compact tabbed UI.
- The script is tiny (~50 LOC, vanilla, no library) and inlined in the include so it ships with the SSR'd HTML and doesn't need a build step.

**Data layer**
- No changes to `_data/experience.yml` — same six entries (Microsoft AI, Xandr consolidated, RUniteCS, AppNexus, Prudential Experimental Laboratory, Viacom Media Networks).

## 3. Published section — drop trailing `→` on package badges

The PyPI / GitHub links in `_includes/packages.html` use the existing `.arrow-link` class, which adds a `→` glyph via `::after`. On these badges the arrow reads as "view more →" and the one after the last (GitHub) link looks dangling.

Added a one-line override:

```css
.package__links .arrow-link:after { display: none; content: none; }
```

So PyPI / GitHub render as clean inline labels. The base `.arrow-link` style is unchanged for the rest of the site.

## Files changed

- `_data/now.yml` — Currently text.
- `_includes/experience.html` — full rewrite (tabbed UI + script).
- `css/main.css` — appended `.exp-tabs` rules (no-JS stacked view, JS desktop vertical rail, JS mobile horizontal strip, dark-mode pairs at `#4dabff`); appended `.package__links .arrow-link:after` suppressor.

## Verification

- `_data/now.yml` and `_data/experience.yml` both parse cleanly with `yaml.safe_load`.
- Liquid templating reuses the existing patterns (`forloop.index0`, `{{ job.url }}`, etc.).
- No new asset files; no `_config.yml` changes; no build-step changes.

Branch: `nh/experience-tabs-2026-06`
