### PR TITLE
Fix tabbed Experience: JS bug + visual tuning

### DIFF
--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -45,6 +45,7 @@
     - Used Puppet, Kubernetes / Docker, and NGINX load balancers to manage infrastructure
 
 - company: Prudential Experimental Laboratory
+  short_name: Prudential
   url: https://www.prudential.com/
   time: May 2017 - Aug 2017
   position: Software Development Intern
@@ -55,6 +56,7 @@
     - Built data visualization applications with D3 and Tableau
 
 - company: Viacom Media Networks
+  short_name: Viacom
   url: https://www.viacomcbs.com/
   time: Jan 2016 - Sep 2016
   position: Software Development Intern

--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -12,7 +12,7 @@
                   aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
                   aria-controls="exp-panel-{{forloop.index0}}"
                   tabindex="{% if forloop.first %}0{% else %}-1{% endif %}">
-            {{ job.company }}
+            {{ job.short_name | default: job.company }}
           </button>
         </li>
         {% endfor %}
@@ -50,8 +50,8 @@
 
 <script>
   (function () {
-    // Progressive-enhancement: only enable tabbed UI when JS is on.
-    // No-JS users see all panels stacked.
+    /* Progressive-enhancement: only enable tabbed UI when JS is on. */
+    /* No-JS users see all panels stacked. */
     var roots = document.querySelectorAll('[data-exp-tabs]');
     roots.forEach(function (root) {
       root.classList.add('exp-tabs--js');

--- a/css/main.css
+++ b/css/main.css
@@ -66,9 +66,9 @@ body.night .writing-post__nav{border-top-color:#2a3344}
 .exp-tabs{display:block}
 .exp-tabs__list{list-style:none;padding:0;margin:0 0 30px;display:flex;overflow-x:auto;-webkit-overflow-scrolling:touch;border-bottom:1px solid #e5e5e5}
 .exp-tabs__list-item{margin:0}
-.exp-tabs__tab{font-family:inherit;font-size:.85rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#666;background:transparent;border:0;border-bottom:2px solid transparent;padding:14px 18px;cursor:pointer;white-space:nowrap;transition:color .2s ease-in-out,border-color .2s ease-in-out,background-color .2s ease-in-out;outline:none}
+.exp-tabs__tab{font-family:inherit;font-size:.78rem;font-weight:400;letter-spacing:.5px;text-transform:uppercase;color:#666;background:transparent;border:0;border-bottom:2px solid transparent;padding:14px 18px;cursor:pointer;white-space:nowrap;transition:color .2s ease-in-out,border-color .2s ease-in-out,background-color .2s ease-in-out;outline:none}
 .exp-tabs__tab:hover,.exp-tabs__tab:focus-visible{color:#007bff;background:rgba(0,123,255,0.06)}
-.exp-tabs__tab.is-active{color:#007bff;border-bottom-color:#007bff}
+.exp-tabs__tab.is-active{color:#007bff;border-bottom-color:#007bff;font-weight:700}
 .exp-tabs__panel{padding:4px 4px 24px}
 .exp-tabs__panel:not(:last-of-type){border-bottom:1px solid #f0f0f3;margin-bottom:20px;padding-bottom:32px}
 .exp-tabs__heading{margin:0 0 6px;font-size:1.1rem;font-weight:700;line-height:1.4}
@@ -82,11 +82,11 @@ body.night .writing-post__nav{border-top-color:#2a3344}
 
 /* JS-enhanced view: vertical tab list on desktop, only active panel visible */
 @media screen and (min-width:769px){
-  .exp-tabs--js{display:flex;align-items:flex-start;gap:30px}
-  .exp-tabs--js .exp-tabs__list{flex-direction:column;flex-shrink:0;min-width:200px;max-width:260px;margin:0;border-bottom:none;border-left:1px solid #e5e5e5;overflow-x:visible}
+  .exp-tabs--js{display:flex;align-items:flex-start;gap:24px}
+  .exp-tabs--js .exp-tabs__list{flex-direction:column;flex-shrink:0;width:170px;margin:0;border-bottom:none;border-left:1px solid #e5e5e5;overflow-x:visible}
   .exp-tabs--js .exp-tabs__list-item{display:block}
-  .exp-tabs--js .exp-tabs__tab{display:block;width:100%;text-align:left;padding:12px 18px;border-bottom:0;border-left:2px solid transparent;margin-left:-1px}
-  .exp-tabs--js .exp-tabs__tab.is-active{border-bottom:0;border-left-color:#007bff}
+  .exp-tabs--js .exp-tabs__tab{display:block;width:100%;text-align:left;padding:10px 14px;border-bottom:0;border-left:2px solid transparent;margin-left:-1px;white-space:normal;line-height:1.3;text-transform:none;letter-spacing:0;font-size:.85rem}
+  .exp-tabs--js .exp-tabs__tab.is-active{border-bottom:0;border-left-color:#007bff;background:rgba(0,123,255,0.06)}
   .exp-tabs--js .exp-tabs__panels{flex:1;min-width:0}
   .exp-tabs--js .exp-tabs__panel{display:none;padding:0}
   .exp-tabs--js .exp-tabs__panel:not(:last-of-type){border-bottom:none;margin-bottom:0;padding-bottom:0}
@@ -105,7 +105,7 @@ body.night .exp-tabs--js .exp-tabs__list{border-left-color:#2a3344;border-bottom
 body.night .exp-tabs__tab{color:#9a9ab0}
 body.night .exp-tabs__tab:hover,body.night .exp-tabs__tab:focus-visible{color:#4dabff;background:rgba(77,171,255,0.08)}
 body.night .exp-tabs__tab.is-active{color:#4dabff;border-bottom-color:#4dabff}
-body.night .exp-tabs--js .exp-tabs__tab.is-active{border-left-color:#4dabff;border-bottom-color:transparent}
+body.night .exp-tabs--js .exp-tabs__tab.is-active{border-left-color:#4dabff;border-bottom-color:transparent;background:rgba(77,171,255,0.08)}
 body.night .exp-tabs__position{color:#e7e7e7}
 body.night .exp-tabs__at{color:#9a9ab0}
 body.night .exp-tabs__company-link{color:#4dabff}


### PR DESCRIPTION
# Fix tabbed Experience: JS bug + visual tuning

PR #11 shipped the tabbed layout but the JS never ran on the live site, so visitors saw the no-JS stacked panels (everything visible, mobile-style horizontal-scroll tab strip on top) instead of the desktop Brittany-Chiang vertical-rail layout.

## Root cause

The site's `_layouts/compress.html` strips newlines from the final HTML before it's served. The inline tab-switching script used `//` line comments — after newline-stripping, those comments turned into a single line that swallowed the rest of the script body (`var roots = …` onward). The `exp-tabs--js` class was therefore never added, so neither the desktop two-column layout nor the click-to-switch behavior activated.

I caught this by inspecting the live HTML on https://naeemh.github.io/, where the rendered `<script>` showed up as one long line beginning with `(function () { // Progressive-enhancement: …`, with the rest of the function silently commented out.

## Changes

**`_includes/experience.html`**
- Swapped the two `//` comments for `/* … */` block comments so the script survives newline collapsing. Script behavior is otherwise identical.
- Tab label now reads from `{{ job.short_name | default: job.company }}` so we can keep the long formal name on the panel heading (e.g. `Software Development Intern @ Prudential Experimental Laboratory`) while the rail label stays short.

**`_data/experience.yml`**
- Added `short_name: Prudential` on the Prudential entry.
- Added `short_name: Viacom` on the Viacom entry.
- All other entries fall back to the full `company` value, so the rail reads `Microsoft AI`, `Xandr`, `RUniteCS`, `AppNexus`, `Prudential`, `Viacom`.

**`css/main.css`** (visual tuning to match v4.brittanychiang.com more closely)
- Desktop JS rail width fixed at **170px** (was 200–260px range), gap 24px.
- Rail tabs render in natural case (no uppercase), no letter-spacing, font-weight 400 inactive / 700 active, with natural line-wrapping enabled.
- Active rail tab now also gets a subtle accent-tinted background (`rgba(0,123,255,0.06)` / `rgba(77,171,255,0.08)` in dark mode) on top of the left-border indicator — matches Brittany's hover/active treatment.
- The base (no-JS / mobile) horizontal-strip view keeps uppercase + letter-spacing so it reads as a clean tab strip on small screens.

## Expected result

After this lands, on desktop the Experience section shows:
- A 170px vertical rail of company labels on the left, with a 1px gray left-line and a 2px accent line + tinted background on the active tab.
- The right side shows only the active panel — `Position @ Company` heading, monospace `time · location`, accent-chevron bullets.
- Clicking a rail tab swaps the panel; keyboard arrows / Home / End work as before.

On mobile the layout collapses to a horizontal scrollable tab strip on top with a single panel below.

## Verification

- `grep '//' _includes/experience.html` → 0 (the remaining JS-meaningful content is comment-free).
- `yaml.safe_load(_data/experience.yml)` parses clean.
- No new asset files; no config changes.

Branch: `nh/experience-tabs-fix-2026-06`
