### PR TITLE
Polish: hide Writing link, unbold closing line, widen Skills

### DIFF
--- a/_includes/background.html
+++ b/_includes/background.html
@@ -44,7 +44,7 @@
 
 
     <p>
-      <strong>When I'm not in front of a computer screen</strong>, I'm probably cooking or adventuring!
+      When I'm not in front of a computer screen, I'm probably cooking or adventuring!
     </p>
   </div>
 </section>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,12 +19,6 @@
       <img src="{{site.baseurl}}/img/social/{{link.title}}.svg" alt="{{link.title}}" width="22" height="22">
     </a>
     {% endfor %}
-    {% if site.posts.size > 0 %}
-    <a href="{{site.baseurl}}/writing/" title="writing">
-      <span class="text">writing</span>
-      <img src="{{site.baseurl}}/img/social/writing.svg" alt="writing" width="22" height="22">
-    </a>
-    {% endif %}
   </div>
 </footer>
 </div>

--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -50,12 +50,6 @@
           <img src="{{site.baseurl}}/img/social/{{link.title}}.svg" alt="{{link.title}}" width="22" height="22">
         </a>
         {% endfor %}
-        {% if site.posts.size > 0 %}
-        <a href="{{site.baseurl}}/writing/" title="writing">
-          <span class="text">writing</span>
-          <img src="{{site.baseurl}}/img/social/writing.svg" alt="writing" width="22" height="22">
-        </a>
-        {% endif %}
       </div>
     </footer>
   <!--  </div> -->

--- a/css/main.css
+++ b/css/main.css
@@ -112,3 +112,9 @@ body.night .exp-tabs__company-link{color:#4dabff}
 body.night .exp-tabs__meta{color:#9a9ab0}
 body.night .exp-tabs__bullets li:before{border-right-color:#4dabff;border-bottom-color:#4dabff}
 body.night .exp-tabs__panel:not(:last-of-type){border-bottom-color:#2a3344}
+
+/* Skills section: spread categories wider (added 2026-06-22) */
+.skills .section__content{max-width:820px}
+.skills .skillz{gap:34px}
+@media screen and (max-width:1024px){.skills .section__content{max-width:760px}}
+@media screen and (max-width:768px){.skills .section__content{max-width:none}}


### PR DESCRIPTION
# Polish: hide Writing link, unbold closing line, widen Skills

Three small UI tweaks per user feedback. No content moves, no roadmap impact.

## 1. Hide the homepage Writing link (keep all writing infrastructure)

Removed the gated Writing entry from both `footer__links` loops (intro mini-footer + main page footer). The section is still sparse / pre-revamp, so the user wants it hidden from the homepage until they're ready to refresh it.

**Intentionally left untouched** so the link can be reinstated by re-adding the same `{% if site.posts.size > 0 %}` block later:
- `/writing/` route (`_includes/writing.html` / wherever the index lives)
- `_layouts/post.html` and the BlogPosting JSON-LD
- `_posts/*` (existing prose + stubs)
- RSS feed from `jekyll-feed`
- `img/social/writing.svg` (the feather pencil icon)

## 2. Unbold the closing line in Background

Dropped the `<strong>` tags around `When I'm not in front of a computer screen`. The bolding was a holdover from earlier copy that treated that opening clause as a callout; on the trimmed `cooking or adventuring!` line it read as accidental overflow rather than emphasis.

```diff
-<strong>When I'm not in front of a computer screen</strong>, I'm probably cooking or adventuring!
+When I'm not in front of a computer screen, I'm probably cooking or adventuring!
```

## 3. Widen Skills section

The five Skills categories (`Languages` / `Distributed` / `Workflows` / `AI` / `OS`) were crowded together inside the default `.section__content { max-width: 650px }` cap and reading as one cramped row.

Appended a small set of overrides scoped strictly to `.skills`:

```css
.skills .section__content{max-width:820px}
.skills .skillz{gap:34px}
@media screen and (max-width:1024px){.skills .section__content{max-width:760px}}
@media screen and (max-width:768px){.skills .section__content{max-width:none}}
```

- Desktop: `820px` content cap (~26% wider than the previous 650px), with a 34px gap between category columns.
- Tablet (≤1024px): `760px` cap (still wider than other sections, lets the columns breathe through the `padding:50px` regime).
- Mobile (≤768px): cap removed; the existing 47%-width / wrap-to-two-columns behavior in the base CSS continues to apply.

Other sections (`background`, `experience`, `published`, `projects`) stay at the original 650px cap.

## Files changed

- `_includes/intro.html` — removed the trailing Writing `<a>` from the social loop.
- `_includes/footer.html` — same removal in the bottom-of-page social loop.
- `_includes/background.html` — dropped `<strong>` wrap.
- `css/main.css` — appended four lines of skills overrides.

## Verification

- `grep -c '/writing/' _includes/intro.html _includes/footer.html` → `0` in both files.
- The `/writing/` route still resolves at https://naeemh.github.io/writing/ after this lands (no template or post deletion).
- YAML untouched.

Branch: `nh/polish-2026-06`
