### PR TITLE
Widen all section content blocks to match Skills

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -113,8 +113,8 @@ body.night .exp-tabs__meta{color:#9a9ab0}
 body.night .exp-tabs__bullets li:before{border-right-color:#4dabff;border-bottom-color:#4dabff}
 body.night .exp-tabs__panel:not(:last-of-type){border-bottom-color:#2a3344}
 
-/* Skills section: spread categories wider (added 2026-06-22) */
-.skills .section__content{max-width:820px}
+/* Widen all section content blocks to match Skills (added 2026-06-22) */
+.section__content{max-width:820px}
 .skills .skillz{gap:34px}
-@media screen and (max-width:1024px){.skills .section__content{max-width:760px}}
-@media screen and (max-width:768px){.skills .section__content{max-width:none}}
+@media screen and (max-width:1024px){.section__content{max-width:760px}}
+@media screen and (max-width:768px){.section__content{max-width:none}}


### PR DESCRIPTION
# Widen all section content blocks to match Skills

## Problem

PR #13 widened only `.skills .section__content` to 820px (desktop) / 760px (tablet), which left Background, Experience, Published, and Projects still capped at the original `.section__content { max-width: 650px }`. The result was a visually askew page: the Skills row extended noticeably further right than every other section.

## Fix

Promoted the override from `.skills .section__content` to a bare `.section__content` selector so every section block shares the same width cap:

```diff
-/* Skills section: spread categories wider (added 2026-06-22) */
-.skills .section__content{max-width:820px}
+/* Widen all section content blocks to match Skills (added 2026-06-22) */
+.section__content{max-width:820px}
 .skills .skillz{gap:34px}
-@media screen and (max-width:1024px){.skills .section__content{max-width:760px}}
-@media screen and (max-width:768px){.skills .section__content{max-width:none}}
+@media screen and (max-width:1024px){.section__content{max-width:760px}}
+@media screen and (max-width:768px){.section__content{max-width:none}}
```

Behavior by viewport:
- **Desktop**: every section's `.section__content` capped at 820px (was 650px for non-skills).
- **Tablet (≤1024px)**: every section capped at 760px.
- **Mobile (≤768px)**: cap removed; sections stack via the existing `.section { display:block }` rule.

## Preserved

`.skills .skillz { gap:34px }` is untouched — that rule controls inter-column spacing on the 5-category Skills grid, which the other sections don't use.

## Files changed

- `css/main.css` — 4-line override block at the bottom retargeted from `.skills .section__content` to `.section__content`.

Branch: `nh/widen-sections-2026-06`
