### PR TITLE
Add printable /cv/ route

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,184 @@
+---
+layout: default
+title: CV
+permalink: /cv/
+description: "Printable CV / résumé for Naeem Hossain — experience, skills, and certifications, generated from the same data that powers the site."
+---
+<style>
+  /* Screen styling — scoped to the /cv/ page only. */
+  .cv {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 70px 40px 100px;
+    line-height: 1.5;
+  }
+  .cv a { color: #007bff; }
+  body.night .cv a { color: #4dabff; }
+
+  .cv__header { margin-bottom: 40px; }
+  .cv__name {
+    font-size: 2.25rem;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: 1px;
+  }
+  .cv__title {
+    font-size: 1.1rem;
+    font-weight: 400;
+    margin: 4px 0 10px;
+  }
+  .cv__contact {
+    font-family: Inconsolata, monospace;
+    font-size: 0.9rem;
+    margin: 0 0 20px;
+  }
+  .cv__contact a { white-space: nowrap; }
+  .cv__print {
+    font-family: Inconsolata, monospace;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #007bff;
+    background: transparent;
+    border: 1px solid #007bff;
+    border-radius: 4px;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+  }
+  .cv__print:hover { background: #007bff; color: #fff; }
+  body.night .cv__print { color: #4dabff; border-color: #4dabff; }
+  body.night .cv__print:hover { background: #4dabff; color: #16161a; }
+
+  .cv__section { margin-bottom: 36px; }
+  .cv__section-title {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+    color: #007bff;
+    border-bottom: 1px solid #36363c;
+    padding-bottom: 6px;
+    margin: 0 0 18px;
+  }
+  body.night .cv__section-title { color: #4dabff; }
+
+  .cv__job { margin-bottom: 22px; }
+  .cv__job-head {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .cv__job-role { font-weight: 700; }
+  .cv__job-time {
+    font-family: Inconsolata, monospace;
+    font-size: 0.85rem;
+    white-space: nowrap;
+  }
+  .cv__job-sub {
+    font-size: 0.9rem;
+    margin-bottom: 6px;
+  }
+  .cv__bullets {
+    margin: 6px 0 0;
+    padding-left: 20px;
+  }
+  .cv__bullets li {
+    font-size: 0.9rem;
+    margin: 3px 0;
+  }
+
+  .cv__skill-row { margin-bottom: 8px; font-size: 0.9rem; }
+  .cv__skill-label {
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 1px;
+    margin-right: 6px;
+  }
+  .cv__cert { margin-bottom: 8px; font-size: 0.9rem; }
+  .cv__cert-provider { font-weight: 700; margin-right: 6px; }
+
+  .cv__back {
+    display: inline-block;
+    margin-top: 30px;
+    font-family: Inconsolata, monospace;
+    font-size: 0.85rem;
+  }
+
+  /* Print / Save-as-PDF styling. */
+  @media print {
+    .switch-wrapper,
+    #top-button,
+    .cv__print,
+    .cv__back { display: none !important; }
+
+    body,
+    body.night { background: #fff !important; color: #000 !important; }
+
+    .cv { max-width: none; padding: 0; font-size: 11pt; line-height: 1.35; }
+    .cv a,
+    body.night .cv a { color: #000; text-decoration: none; }
+    .cv__section-title,
+    body.night .cv__section-title { color: #000; border-bottom: 1px solid #000; }
+    .cv__job { page-break-inside: avoid; }
+    .cv__section { page-break-inside: avoid; }
+    @page { margin: 1.6cm; }
+  }
+</style>
+
+<article class="cv" id="cv">
+  <header class="cv__header">
+    <h1 class="cv__name">Naeem Hossain</h1>
+    <p class="cv__title">Senior Software Engineer &middot; Systems &amp; Software</p>
+    <p class="cv__contact">
+      <a href="mailto:naeemhossain.mail@gmail.com">NaeemHossain.mail@gmail.com</a> &middot;
+      <a href="https://github.com/NaeemH" target="_blank" rel="noopener">github.com/NaeemH</a> &middot;
+      <a href="https://www.linkedin.com/in/naeem-hossain" target="_blank" rel="noopener">linkedin.com/in/naeem-hossain</a> &middot;
+      <a href="https://naeemh.github.io">naeemh.github.io</a>
+    </p>
+    <button type="button" class="cv__print" onclick="window.print()">Print / Save as PDF</button>
+  </header>
+
+  <section class="cv__section">
+    <h2 class="cv__section-title">Experience</h2>
+    {% for job in site.data.experience %}
+    <div class="cv__job">
+      <div class="cv__job-head">
+        <span class="cv__job-role">{{ job.position }}</span>
+        <span class="cv__job-time">{{ job.time }}</span>
+      </div>
+      <div class="cv__job-sub">
+        <a href="{{ job.url }}" target="_blank" rel="noopener">{{ job.company }}</a>{% if job.location %} &middot; {{ job.location }}{% endif %}
+      </div>
+      {% if job.description %}
+      <ul class="cv__bullets">
+        {% for bullet in job.description %}
+        <li>{{ bullet }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </section>
+
+  <section class="cv__section">
+    <h2 class="cv__section-title">Skills</h2>
+    <div class="cv__skill-row"><span class="cv__skill-label">Languages</span>{% for x in site.data.skills.languages %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    <div class="cv__skill-row"><span class="cv__skill-label">Distributed</span>{% for x in site.data.skills.dm %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    <div class="cv__skill-row"><span class="cv__skill-label">Workflows</span>{% for x in site.data.skills.wm %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    <div class="cv__skill-row"><span class="cv__skill-label">AI</span>{% for x in site.data.skills.ai %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    <div class="cv__skill-row"><span class="cv__skill-label">OS</span>{% for x in site.data.skills.ose %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+  </section>
+
+  <section class="cv__section">
+    <h2 class="cv__section-title">Certifications</h2>
+    {% for group in site.data.certifications.groups %}
+    <div class="cv__cert"><span class="cv__cert-provider">{{ group.provider }}</span>{% for item in group.items %}{{ item.name }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    {% endfor %}
+  </section>
+
+  <a class="cv__back arrow-link" href="/">&larr; Back to site</a>
+</article>


### PR DESCRIPTION
Adds a `/cv/` page that renders `_data/experience.yml`, `skills.yml`, and `certifications.yaml` — one source of truth instead of a separately-maintained PDF.

### Features
- Clean, readable layout reusing the site's accent colors and monospace type.
- **Print / Save as PDF** button (`window.print()`).
- `@media print` styles: hide theme toggle / top-button / buttons, force black-on-white, `page-break-inside: avoid` on jobs and sections, 1.6cm page margin.
- Dark-mode aware on screen.

### Notes
- Styling is a page-scoped `<style>` block because `css/main.css` is a committed, pre-minified artifact (its SCSS source has no front matter, so Jekyll doesn't rebuild it) — this avoids touching the offline SASS pipeline.
- Validated statically (front matter, balanced Liquid tags, data-key references); local Jekyll build skipped due to native-ext compile issues in this env — GitHub Pages builds on merge.