### PR TITLE
Rename cryptic skills.yml keys

### DIFF
--- a/_data/skills.yml
+++ b/_data/skills.yml
@@ -7,7 +7,7 @@ languages:
   - item: SQL
   - item: JavaScript
 
-dm:
+infrastructure:
   - item: Azure
   - item: Kubernetes
   - item: Docker
@@ -17,7 +17,7 @@ dm:
   - item: Ansible
   - item: Helm
 
-wm:
+workflows:
   - item: Git (GitHub, Azure DevOps)
   - item: GitHub Actions
   - item: Azure DevOps Pipelines
@@ -31,7 +31,7 @@ ai:
   - item: Gemini
   - item: GPT
 
-ose:
+operating_systems:
   - item: Ubuntu (20.04 - 24.04)
   - item: RHEL / Debian
   - item: macOS

--- a/_includes/skills.html
+++ b/_includes/skills.html
@@ -14,7 +14,7 @@
       <div class="skillz__category">
         <div class="skillz__category__label">Distributed</div>
         <ul>
-          {% for tool in site.data.skills.dm %}
+          {% for tool in site.data.skills.infrastructure %}
           <li class="skillz__category__item">{{tool.item}}</li>
           {% endfor %}
         </ul>
@@ -22,7 +22,7 @@
       <div class="skillz__category">
         <div class="skillz__category__label">Workflows</div>
         <ul>
-          {% for workflow in site.data.skills.wm %}
+          {% for workflow in site.data.skills.workflows %}
           <li class="skillz__category__item">{{workflow.item}}</li>
           {% endfor %}
         </ul>
@@ -38,7 +38,7 @@
       <div class="skillz__category">
         <div class="skillz__category__label">OS</div>
         <ul>
-          {% for thing in site.data.skills.ose %}
+          {% for thing in site.data.skills.operating_systems %}
           <li class="skillz__category__item">{{thing.item}}</li>
           {% endfor %}
         </ul>

--- a/cv.html
+++ b/cv.html
@@ -167,10 +167,10 @@ description: "Printable CV / résumé for Naeem Hossain — experience, skills, 
   <section class="cv__section">
     <h2 class="cv__section-title">Skills</h2>
     <div class="cv__skill-row"><span class="cv__skill-label">Languages</span>{% for x in site.data.skills.languages %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
-    <div class="cv__skill-row"><span class="cv__skill-label">Distributed</span>{% for x in site.data.skills.dm %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
-    <div class="cv__skill-row"><span class="cv__skill-label">Workflows</span>{% for x in site.data.skills.wm %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    <div class="cv__skill-row"><span class="cv__skill-label">Distributed</span>{% for x in site.data.skills.infrastructure %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    <div class="cv__skill-row"><span class="cv__skill-label">Workflows</span>{% for x in site.data.skills.workflows %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
     <div class="cv__skill-row"><span class="cv__skill-label">AI</span>{% for x in site.data.skills.ai %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
-    <div class="cv__skill-row"><span class="cv__skill-label">OS</span>{% for x in site.data.skills.ose %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
+    <div class="cv__skill-row"><span class="cv__skill-label">OS</span>{% for x in site.data.skills.operating_systems %}{{ x.item }}{% unless forloop.last %}, {% endunless %}{% endfor %}</div>
   </section>
 
   <section class="cv__section">


### PR DESCRIPTION
Renames the opaque `_data/skills.yml` keys to self-documenting names:

- `dm` → `infrastructure`
- `wm` → `workflows`
- `ose` → `operating_systems`

Updates the loops in `_includes/skills.html` and `cv.html`. Visible category labels are unchanged, so the rendered output is byte-identical — this is a readability-only refactor of the data file.