### PR TITLE
Add Photography link to social rows (config-gated)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,12 @@ social:
   - title: email
     url: mailto:naeemhossain.mail@gmail.com
 
+# Photography portfolio link — shows a "photography" icon in the intro + footer
+# social rows once a URL is set. Point it at your public gallery/profile
+# (Instagram, Flickr, a Google Photos shared album, a portfolio host, etc.).
+# Leave empty to keep the link hidden; no photos are uploaded to this repo.
+photography:
+
 # Build settings
 markdown: kramdown
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,6 +19,12 @@
       <img src="{{site.baseurl}}/img/social/{{link.title}}.svg" alt="{{link.title}}" width="22" height="22">
     </a>
     {% endfor %}
+    {% if site.photography %}
+    <a href="{{ site.photography }}" target="_blank" rel="noopener" title="photography">
+      <span class="text">photography</span>
+      <img src="{{site.baseurl}}/img/social/photography.svg" alt="photography" width="22" height="22">
+    </a>
+    {% endif %}
   </div>
 </footer>
 </div>

--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -50,6 +50,12 @@
           <img src="{{site.baseurl}}/img/social/{{link.title}}.svg" alt="{{link.title}}" width="22" height="22">
         </a>
         {% endfor %}
+        {% if site.photography %}
+        <a href="{{ site.photography }}" target="_blank" rel="noopener" title="photography">
+          <span class="text">photography</span>
+          <img src="{{site.baseurl}}/img/social/photography.svg" alt="photography" width="22" height="22">
+        </a>
+        {% endif %}
       </div>
     </footer>
   <!--  </div> -->

--- a/img/social/photography.svg
+++ b/img/social/photography.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     x="0px" y="0px" width="512px" height="512px" viewBox="0 0 512 512" fill="#007BFF"
+     style="enable-background:new 0 0 512 512;" xml:space="preserve">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M186.7,80c-13.4,0-25.8,6.7-33.2,17.8L133.3,128H72
+        c-30.9,0-56,25.1-56,56v224c0,30.9,25.1,56,56,56h368c30.9,0,56-25.1,56-56V184c0-30.9-25.1-56-56-56
+        h-61.3l-20.2-30.2C351.1,86.7,338.7,80,325.3,80H186.7z M256,192c-53,0-96,43-96,96s43,96,96,96
+        s96-43,96-96S309,192,256,192z M256,240c26.5,0,48,21.5,48,48s-21.5,48-48,48s-48-21.5-48-48
+        S229.5,240,256,240z"/>
+</svg>


### PR DESCRIPTION
Adds a **Photography** link to the intro + footer social rows (next to Resume / GitHub / LinkedIn / Email), with a matching camera icon in the existing `#007BFF` style.

### How it works
- Controlled by a new `photography:` key in `_config.yml`. The link renders only when a URL is set, so it's **dormant by default** — nothing broken ships.
- **No photos are uploaded to the repo** (avoids quality loss / bloat). The link points to an external gallery/profile — Instagram, Flickr, a Google Photos shared album, or any portfolio host.

### To activate
Set `photography: <your-public-gallery-url>` in `_config.yml` and it appears in both social rows automatically.

### Notes on API embedding (for later, if wanted)
A *live embedded gallery* is a separate project. Instagram's Basic Display API was deprecated (Dec 2024) and Google Photos' Library API was restricted (Mar 2025), so **Flickr's API** is the best trusted free path for that — tracked as a future enhancement.